### PR TITLE
Use local gulp + npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,27 @@ An open source HTML and CSS toolkit. With prebuilt modules and a responsive desi
 
 Built with **SMACSS, BEM and WAI-ARIA**.
 
-## Local development
+## Development
 
 Fannypack runs on [Hugo](https://gohugo.io/), a static site generator and [Gulp](https://gulpjs.com/) as task manager.
 
-To run a local server and start developing, open up 2 teminal windows and run the following commands
+### Dependencies
+- NodeJS v6.X & NPM: https://nodejs.org/dist/latest-v6.x/
+- Hugo: https://gohugo.io/getting-started/installing/
+
+### Run local
 
 ```bash
-# in window 1 - run a local development server and watch the files for changes
-$ cd fannypack && hugo server
-
-# in window 2 - build & watch the assets for changes (css, fonts, img, ...)
-$ cd fannypack && gulp
+# start hugo server and build/watch static files with gulp
+npm run develop
 ```
 
 ## Pushing code
 
 Before you can push your code, you need to build the static site.
 
-The build command:
-
 ```bash
-$ hugo
+npm run build
 ```
 
 Fannypack maintainers can now push the code to the remote `master` branch. This will trigger an auto-deploy.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "De Persgroep Styleguide for all internal applications",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "hugo server",
+    "develop": "hugo server & ./node_modules/gulp/bin/gulp.js default",
+    "build": "hugo"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Add scripts for development: `npm run develop` and `npm run build`
- Remove need for global gulp

Hugo will have to be installed global manually for now. Go doesn't have an official package manager: [dep](https://github.com/golang/dep) is in development